### PR TITLE
Papers Past: Enhanced metadata extraction for newspapers

### DIFF
--- a/Papers Past.js
+++ b/Papers Past.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-10-20 10:00:00"
+	"lastUpdated": "2025-10-02 12:00:00"
 }
 
 /*
@@ -103,11 +103,10 @@ function scrapeNewspaper(doc, url) {
 	item.title = fixTitleCase(rawTitle);
 
 	// Publication
-	item.publicationTitle =
-		(news && news.isPartOf && news.isPartOf.name) ||
-		meta.hw.citation_journal_title ||
-		meta.dc["DC.publisher"] ||
-		meta.dc["DC.source"] || "";
+	item.publicationTitle = (news && news.isPartOf && news.isPartOf.name)
+		|| meta.hw.citation_journal_title
+		|| meta.dc["DC.publisher"]
+		|| meta.dc["DC.source"] || "";
 
 	// Date
 	item.date = ZU.strToISO((news && news.datePublished) || meta.hw.citation_date || meta.dc["DC.date"] || "");
@@ -219,10 +218,10 @@ function scrape(doc, url) {
 		item.language = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]//tr[td[.="Language"]]/td[2]');
 	}
 	
-	item.abstractNote = text(doc, '#tab-english');
+	item.abstractNote = getText(doc, '#tab-english');
 	item.url = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]/input/@value');
 	if (!item.url) {
-		item.url = text(doc, '#researcher-tools-tab p');
+		item.url = getText(doc, '#researcher-tools-tab p');
 	}
 	if (!item.url || !item.url.startsWith('http')) {
 		item.url = url;
@@ -233,13 +232,13 @@ function scrape(doc, url) {
 		document: doc
 	});
 	
-	let imagePageURL = attr(doc, '.imagecontainer a', 'href');
+	var imagePageURL = getAttr(doc, '.imagecontainer a', 'href');
 	if (imagePageURL) {
 		ZU.processDocuments(imagePageURL, function (imageDoc) {
 			item.attachments.push({
 				title: 'Image',
 				mimeType: 'image/jpeg',
-				url: attr(imageDoc, '.imagecontainer img', 'src')
+				url: getAttr(imageDoc, '.imagecontainer img', 'src')
 			});
 			item.complete();
 		});
@@ -249,12 +248,12 @@ function scrape(doc, url) {
 	}
 }
 
-function text(doc, selector) {
+function getText(doc, selector) {
 	var elem = doc.querySelector(selector);
 	return elem ? elem.textContent : null;
 }
 
-function attr(doc, selector, attribute) {
+function getAttr(doc, selector, attribute) {
 	var elem = doc.querySelector(selector);
 	return elem ? elem.getAttribute(attribute) : null;
 }
@@ -307,7 +306,7 @@ function collectMeta(doc) {
 }
 
 function parseBibliographicDetails(doc) {
-	var textContent = text(doc, '#researcher-tools-tab .citation, .tabs-panel .citation, p.citation') || "";
+	var textContent = getText(doc, '#researcher-tools-tab .citation, .tabs-panel .citation, p.citation') || "";
 	var out = { publicationTitle: "", volume: "", issue: "", date: "", pages: "" };
 	if (!textContent) return out;
 
@@ -323,7 +322,7 @@ function parseBibliographicDetails(doc) {
 	var dateMatch = textContent.match(/Issue\s+[^,]+,\s*([^,]+),\s*Page/i) || textContent.match(/,\s*([^,]+),\s*Page/i);
 	if (dateMatch) out.date = ZU.trimInternal(dateMatch[1]);
 
-	var pageMatch = textContent.match(/Page\s+([0-9A-Za-z\-]+)/i);
+	var pageMatch = textContent.match(/Page\s+([0-9A-Za-z-]+)/i);
 	if (pageMatch) out.pages = ZU.trimInternal(pageMatch[1]);
 
 	return out;

--- a/Papers Past.js
+++ b/Papers Past.js
@@ -1,16 +1,16 @@
-var translator = {
-	"translatorID": "1b052690-16dd-431d-9828-9dc675eb55f6",
-	"label": "Papers Past",
-	"creator": "Philipp Zumstein, Abe Jellinek, and Jason Murphy",
-	"target": "^https?://(www\\.)?paperspast\\.natlib\\.govt\\.nz/",
-	"minVersion": "5.0",
-	"maxVersion": "",
-	"priority": 100,
-	"inRepository": true,
-	"translatorType": 4,
-	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-10-20 20:19:53"
-};
+{
+	translatorID: "1b052690-16dd-431d-9828-9dc675eb55f6",
+	label: "Papers Past",
+	creator: "Philipp Zumstein, Abe Jellinek, and Jason Murphy",
+	target: "^https?://(www\\.)?paperspast\\.natlib\\.govt\\.nz/",
+	minVersion: "5.0",
+	maxVersion: "",
+	priority: 100,
+	inRepository: true,
+	translatorType: 4,
+	browserSupport: "gcsibv",
+	lastUpdated: "2025-10-20 20:19:53"
+}
 
 /*
 	***** BEGIN LICENSE BLOCK *****
@@ -365,151 +365,151 @@ function canonicalURL(doc) {
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/newspapers?items_per_page=10&snippet=true&query=argentina",
-		"items": "multiple"
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/newspapers?items_per_page=10&snippet=true&query=argentina",
+		items: "multiple"
 	},
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
-		"items": [
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
+		items: [
 			{
-				"itemType": "newspaperArticle",
-				"title": "Coup in Argentina",
-				"creators": [],
-				"date": "1944-02-18",
-				"libraryCatalog": "Papers Past",
-				"pages": "5",
-				"publicationTitle": "Evening Post",
-				"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
-				"attachments": [
+				itemType: "newspaperArticle",
+				title: "Coup in Argentina",
+				creators: [],
+				date: "1944-02-18",
+				libraryCatalog: "Papers Past",
+				pages: "5",
+				publicationTitle: "Evening Post",
+				url: "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
+				attachments: [
 					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
+						title: "Snapshot",
+						mimeType: "text/html"
 					}
 				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": [],
-				"rights": "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
-				"extra": "Volume: CXXXVII\nIssue: 41"
+				tags: [],
+				notes: [],
+				seeAlso: [],
+				rights: "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
+				extra: "Volume: CXXXVII\nIssue: 41"
 			}
 		]
 	},
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
-		"items": [
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
+		items: [
 			{
-				"itemType": "newspaperArticle",
-				"title": "Inter-School Basketball And Rugby Football",
-				"creators": [],
-				"date": "1939-07-01",
-				"extra": "Volume: 64\nIssue: 153",
-				"libraryCatalog": "Papers Past",
-				"pages": "2",
-				"publicationTitle": "Manawatu Times",
-				"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
-				"attachments": [
+				itemType: "newspaperArticle",
+				title: "Inter-School Basketball And Rugby Football",
+				creators: [],
+				date: "1939-07-01",
+				extra: "Volume: 64\nIssue: 153",
+				libraryCatalog: "Papers Past",
+				pages: "2",
+				publicationTitle: "Manawatu Times",
+				url: "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
+				attachments: [
 					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
+						title: "Snapshot",
+						mimeType: "text/html"
 					}
 				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": [],
-				"rights": "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide."
+				tags: [],
+				notes: [],
+				seeAlso: [],
+				rights: "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide."
 			}
 		]
 	},
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
-		"items": [
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
+		items: [
 			{
-				"itemType": "journalArticle",
-				"title": "\"The Law Within the Law.\"",
-				"creators": [],
-				"date": "1883-11-01",
-				"issue": "2",
-				"libraryCatalog": "Papers Past",
-				"pages": "3",
-				"publicationTitle": "Freethought Review",
-				"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
-				"volume": "I",
-				"attachments": [
+				itemType: "journalArticle",
+				title: "\"The Law Within the Law.\"",
+				creators: [],
+				date: "1883-11-01",
+				issue: "2",
+				libraryCatalog: "Papers Past",
+				pages: "3",
+				publicationTitle: "Freethought Review",
+				url: "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
+				volume: "I",
+				attachments: [
 					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
+						title: "Snapshot",
+						mimeType: "text/html"
 					}
 				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
+				tags: [],
+				notes: [],
+				seeAlso: []
 			}
 		]
 	},
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
-		"items": [
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
+		items: [
 			{
-				"itemType": "letter",
-				"title": "1 Page Written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald Mclean in Wellington",
-				"creators": [
+				itemType: "letter",
+				title: "1 Page Written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald Mclean in Wellington",
+				creators: [
 					{
-						"firstName": "Mackay",
-						"lastName": "James",
-						"creatorType": "author"
+						firstName: "Mackay",
+						lastName: "James",
+						creatorType: "author"
 					},
 					{
-						"firstName": "McLean",
-						"lastName": "Donald",
-						"creatorType": "recipient"
+						firstName: "McLean",
+						lastName: "Donald",
+						creatorType: "recipient"
 					}
 				],
-				"date": "1873-06-19",
-				"language": "English",
-				"libraryCatalog": "Papers Past",
-				"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
-				"attachments": [
+				date: "1873-06-19",
+				language: "English",
+				libraryCatalog: "Papers Past",
+				url: "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
+				attachments: [
 					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
+						title: "Snapshot",
+						mimeType: "text/html"
 					},
 					{
-						"title": "Image",
-						"mimeType": "image/jpeg"
+						title: "Image",
+						mimeType: "image/jpeg"
 					}
 				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
+				tags: [],
+				notes: [],
+				seeAlso: []
 			}
 		]
 	},
 	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
-		"items": [
+		type: "web",
+		url: "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+		items: [
 			{
-				"itemType": "report",
-				"title": "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
-				"creators": [],
-				"libraryCatalog": "Papers Past",
-				"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
-				"attachments": [
+				itemType: "report",
+				title: "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
+				creators: [],
+				libraryCatalog: "Papers Past",
+				url: "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+				attachments: [
 					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
+						title: "Snapshot",
+						mimeType: "text/html"
 					}
 				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
+				tags: [],
+				notes: [],
+				seeAlso: []
 			}
 		]
 	}
-]
+];
 /** END TEST CASES **/

--- a/Papers Past.js
+++ b/Papers Past.js
@@ -1,15 +1,15 @@
 {
-	translatorID: "1b052690-16dd-431d-9828-9dc675eb55f6",
-	label: "Papers Past",
-	creator: "Philipp Zumstein, Abe Jellinek, and Jason Murphy",
-	target: "^https?://(www\\.)?paperspast\\.natlib\\.govt\\.nz/",
-	minVersion: "5.0",
-	maxVersion: "",
-	priority: 100,
-	inRepository: true,
-	translatorType: 4,
-	browserSupport: "gcsibv",
-	lastUpdated: "2025-10-20 20:19:53"
+	"translatorID": "1b052690-16dd-431d-9828-9dc675eb55f6",
+	"label": "Papers Past",
+	"creator": "Philipp Zumstein, Abe Jellinek, and Jason Murphy",
+	"target": "^https?://(www\\.)?paperspast\\.natlib\\.govt\\.nz/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-10-20 20:19:53"
 }
 
 /*
@@ -154,8 +154,8 @@ function scrapeNewspaper(doc, url) {
 
 	item.creators = [];
 	item.attachments = [{
-		title: "Snapshot",
-		document: doc
+		"title": "Snapshot",
+		"document": doc
 	}];
 	item.libraryCatalog = "Papers Past";
 	item.complete();
@@ -234,17 +234,17 @@ function scrapeLegacy(doc, url) {
 	item.libraryCatalog = "Papers Past";
 	
 	item.attachments.push({
-		title: "Snapshot",
-		document: doc
+		"title": "Snapshot",
+		"document": doc
 	});
 	
 	var imagePageURL = attr(doc, '.imagecontainer a', 'href');
 	if (imagePageURL) {
 		ZU.processDocuments(imagePageURL, function (imageDoc) {
 			item.attachments.push({
-				title: 'Image',
-				mimeType: 'image/jpeg',
-				url: attr(imageDoc, '.imagecontainer img', 'src')
+				"title": "Image",
+				"mimeType": "image/jpeg",
+				"url": attr(imageDoc, '.imagecontainer img', 'src')
 			});
 			item.complete();
 		});
@@ -298,12 +298,12 @@ function collectMeta(doc) {
 			dc[name.replace(/^dc\./, "DC.")] = content;
 		}
 	}
-	return { hw: hw, dc: dc };
+	return { "hw": hw, "dc": dc };
 }
 
 function parseBibliographicDetails(doc) {
 	var textContent = text(doc, '#researcher-tools-tab .citation, .tabs-panel .citation, p.citation') || "";
-	var out = { publicationTitle: "", volume: "", issue: "", date: "", pages: "" };
+	var out = { "publicationTitle": "", "volume": "", "issue": "", "date": "", "pages": "" };
 	if (!textContent) return out;
 
 	var pubMatch = textContent.match(/^\s*([^,]+),/);
@@ -365,149 +365,149 @@ function canonicalURL(doc) {
 /** BEGIN TEST CASES **/
 var testCases = [
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/newspapers?items_per_page=10&snippet=true&query=argentina",
-		items: "multiple"
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/newspapers?items_per_page=10&snippet=true&query=argentina",
+		"items": "multiple"
 	},
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
-		items: [
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
+		"items": [
 			{
-				itemType: "newspaperArticle",
-				title: "Coup in Argentina",
-				creators: [],
-				date: "1944-02-18",
-				libraryCatalog: "Papers Past",
-				pages: "5",
-				publicationTitle: "Evening Post",
-				url: "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
-				attachments: [
+				"itemType": "newspaperArticle",
+				"title": "Coup in Argentina",
+				"creators": [],
+				"date": "1944-02-18",
+				"libraryCatalog": "Papers Past",
+				"pages": "5",
+				"publicationTitle": "Evening Post",
+				"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
+				"attachments": [
 					{
-						title: "Snapshot",
-						mimeType: "text/html"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
-				tags: [],
-				notes: [],
-				seeAlso: [],
-				rights: "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
-				extra: "Volume: CXXXVII\nIssue: 41"
+				"tags": [],
+				"notes": [],
+				"seeAlso": [],
+				"rights": "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
+				"extra": "Volume: CXXXVII\nIssue: 41"
 			}
 		]
 	},
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
-		items: [
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
+		"items": [
 			{
-				itemType: "newspaperArticle",
-				title: "Inter-School Basketball And Rugby Football",
-				creators: [],
-				date: "1939-07-01",
-				extra: "Volume: 64\nIssue: 153",
-				libraryCatalog: "Papers Past",
-				pages: "2",
-				publicationTitle: "Manawatu Times",
-				url: "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
-				attachments: [
+				"itemType": "newspaperArticle",
+				"title": "Inter-School Basketball And Rugby Football",
+				"creators": [],
+				"date": "1939-07-01",
+				"extra": "Volume: 64\nIssue: 153",
+				"libraryCatalog": "Papers Past",
+				"pages": "2",
+				"publicationTitle": "Manawatu Times",
+				"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
+				"attachments": [
 					{
-						title: "Snapshot",
-						mimeType: "text/html"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
-				tags: [],
-				notes: [],
-				seeAlso: [],
-				rights: "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide."
+				"tags": [],
+				"notes": [],
+				"seeAlso": [],
+				"rights": "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide."
 			}
 		]
 	},
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
-		items: [
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
+		"items": [
 			{
-				itemType: "journalArticle",
-				title: "\"The Law Within the Law.\"",
-				creators: [],
-				date: "1883-11-01",
-				issue: "2",
-				libraryCatalog: "Papers Past",
-				pages: "3",
-				publicationTitle: "Freethought Review",
-				url: "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
-				volume: "I",
-				attachments: [
+				"itemType": "journalArticle",
+				"title": "\"The Law Within the Law.\"",
+				"creators": [],
+				"date": "1883-11-01",
+				"issue": "2",
+				"libraryCatalog": "Papers Past",
+				"pages": "3",
+				"publicationTitle": "Freethought Review",
+				"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.6.3",
+				"volume": "I",
+				"attachments": [
 					{
-						title: "Snapshot",
-						mimeType: "text/html"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
-				tags: [],
-				notes: [],
-				seeAlso: []
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	},
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
-		items: [
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
+		"items": [
 			{
-				itemType: "letter",
-				title: "1 Page Written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald Mclean in Wellington",
-				creators: [
+				"itemType": "letter",
+				"title": "1 Page Written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald Mclean in Wellington",
+				"creators": [
 					{
-						firstName: "Mackay",
-						lastName: "James",
-						creatorType: "author"
+						"firstName": "Mackay",
+						"lastName": "James",
+						"creatorType": "author"
 					},
 					{
-						firstName: "McLean",
-						lastName: "Donald",
-						creatorType: "recipient"
+						"firstName": "McLean",
+						"lastName": "Donald",
+						"creatorType": "recipient"
 					}
 				],
-				date: "1873-06-19",
-				language: "English",
-				libraryCatalog: "Papers Past",
-				url: "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
-				attachments: [
+				"date": "1873-06-19",
+				"language": "English",
+				"libraryCatalog": "Papers Past",
+				"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
+				"attachments": [
 					{
-						title: "Snapshot",
-						mimeType: "text/html"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					},
 					{
-						title: "Image",
-						mimeType: "image/jpeg"
+						"title": "Image",
+						"mimeType": "image/jpeg"
 					}
 				],
-				tags: [],
-				notes: [],
-				seeAlso: []
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	},
 	{
-		type: "web",
-		url: "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
-		items: [
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+		"items": [
 			{
-				itemType: "report",
-				title: "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
-				creators: [],
-				libraryCatalog: "Papers Past",
-				url: "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
-				attachments: [
+				"itemType": "report",
+				"title": "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
+				"creators": [],
+				"libraryCatalog": "Papers Past",
+				"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+				"attachments": [
 					{
-						title: "Snapshot",
-						mimeType: "text/html"
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
-				tags: [],
-				notes: [],
-				seeAlso: []
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
 			}
 		]
 	}

--- a/Papers Past.js
+++ b/Papers Past.js
@@ -154,8 +154,8 @@ function scrapeNewspaper(doc, url) {
 
 	item.creators = [];
 	item.attachments = [{
-		"title": "Snapshot",
-		"document": doc
+		title: "Snapshot",
+		document: doc
 	}];
 	item.libraryCatalog = "Papers Past";
 	item.complete();
@@ -234,17 +234,17 @@ function scrapeLegacy(doc, url) {
 	item.libraryCatalog = "Papers Past";
 	
 	item.attachments.push({
-		"title": "Snapshot",
-		"document": doc
+		title: "Snapshot",
+		document: doc
 	});
 	
 	var imagePageURL = attr(doc, '.imagecontainer a', 'href');
 	if (imagePageURL) {
 		ZU.processDocuments(imagePageURL, function (imageDoc) {
 			item.attachments.push({
-				"title": "Image",
-				"mimeType": "image/jpeg",
-				"url": attr(imageDoc, '.imagecontainer img', 'src')
+				title: "Image",
+				mimeType: "image/jpeg",
+				url: attr(imageDoc, '.imagecontainer img', 'src')
 			});
 			item.complete();
 		});
@@ -298,12 +298,12 @@ function collectMeta(doc) {
 			dc[name.replace(/^dc\./, "DC.")] = content;
 		}
 	}
-	return { "hw": hw, "dc": dc };
+	return { hw: hw, dc: dc };
 }
 
 function parseBibliographicDetails(doc) {
 	var textContent = text(doc, '#researcher-tools-tab .citation, .tabs-panel .citation, p.citation') || "";
-	var out = { "publicationTitle": "", "volume": "", "issue": "", "date": "", "pages": "" };
+	var out = { publicationTitle: "", volume: "", issue: "", date: "", pages: "" };
 	if (!textContent) return out;
 
 	var pubMatch = textContent.match(/^\s*([^,]+),/);
@@ -511,5 +511,5 @@ var testCases = [
 			}
 		]
 	}
-];
+]
 /** END TEST CASES **/

--- a/Papers Past.js
+++ b/Papers Past.js
@@ -1,21 +1,21 @@
 {
 	"translatorID": "1b052690-16dd-431d-9828-9dc675eb55f6",
 	"label": "Papers Past",
-	"creator": "Philipp Zumstein and Abe Jellinek",
+	"creator": "Philipp Zumstein, Abe Jellinek, and Jason Murphy",
 	"target": "^https?://(www\\.)?paperspast\\.natlib\\.govt\\.nz/",
-	"minVersion": "3.0",
+	"minVersion": "5.0",
 	"maxVersion": "",
-	"priority": 100,
+	"priority": 200,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2021-07-12 17:17:15"
+	"lastUpdated": "2025-09-30 06:00:00"
 }
 
 /*
 	***** BEGIN LICENSE BLOCK *****
 
-	Copyright © 2017-2021 Philipp Zumstein and Abe Jellinek
+	Copyright © 2025 Philipp Zumstein, Abe Jellinek, and Jason Murphy
 
 	This file is part of Zotero.
 
@@ -35,15 +35,31 @@
 	***** END LICENSE BLOCK *****
 */
 
+/*
+	Papers Past Translator
+	
+	Enhanced metadata extraction for newspaper articles using structured data sources
+	(JSON-LD, Highwire Press, Dublin Core) with fallbacks to screen scraping.
+	Legacy scraping maintained for other collection types (periodicals, manuscripts, parliamentary papers). 
+*/
+
+// ============================================================================
+// Detection and Routing
+// ============================================================================
 
 function detectWeb(doc, url) {
+	// Check for newspaper article
+	if (isNewspaperArticle(doc, url)) {
+		return "newspaperArticle";
+	}
+
+	// Handle search results
 	if (/[?&]query=/.test(url) && getSearchResults(doc, true)) {
 		return "multiple";
 	}
+	
+	// Handle other collection types
 	else if (ZU.xpathText(doc, '//h3[@itemprop="headline"]')) {
-		if (url.includes('/newspapers/')) {
-			return "newspaperArticle";
-		}
 		if (url.includes('/periodicals/')) {
 			return "journalArticle";
 		}
@@ -57,6 +73,116 @@ function detectWeb(doc, url) {
 	return false;
 }
 
+function doWeb(doc, url) {
+	var detectedType = detectWeb(doc, url);
+
+	if (detectedType == "newspaperArticle") {
+		scrapeNewspaper(doc, url);
+	}
+	else if (detectedType == "multiple") {
+		Zotero.selectItems(getSearchResults(doc, false), function (items) {
+			if (!items) {
+				return;
+			}
+			var articles = [];
+			for (var i in items) {
+				articles.push(i);
+			}
+			ZU.processDocuments(articles, scrapeLegacy);
+		});
+	}
+	else {
+		scrapeLegacy(doc, url);
+	}
+}
+
+// ============================================================================
+// Newspaper Article Scraper
+// ============================================================================
+
+function isNewspaperArticle(doc, url) {
+	// Check URL pattern
+	if (/\/newspapers\/.+\.\d+\.\d+/.test(url)) return true;
+	
+	// Check for NewsArticle schema
+	const hasNews = getJSONLD(doc)?.some(o => /NewsArticle|Article/i.test(o['@type']));
+	if (hasNews) return true;
+	
+	return false;
+}
+
+function scrapeNewspaper(doc, url) {
+	const item = new Zotero.Item("newspaperArticle");
+	const ld = getJSONLD(doc);
+	const news = ld && ld.find(o => /NewsArticle|Article/i.test(o['@type'])) || null;
+	const meta = collectMeta(doc);
+
+	// Extract title from multiple sources
+	const titles = [];
+	if (news?.headline) titles.push(clean(news.headline));
+	if (meta.hw.citation_title) titles.push(clean(meta.hw.citation_title));
+	if (meta.dc["DC.title"]) titles.push(clean(meta.dc["DC.title"]));
+	item.title = fixTitleCase(dedupeFirst(titles));
+
+	// Publication name
+	item.publicationTitle =
+		news?.isPartOf?.name ||
+		meta.hw.citation_journal_title ||
+		meta.dc["DC.publisher"] ||
+		meta.dc["DC.source"] || "";
+
+	// Publication date
+	item.date =
+		normalizeDate(news?.datePublished) ||
+		normalizeDate(meta.hw.citation_date) ||
+		normalizeDate(meta.dc["DC.date"]) || "";
+
+	// Page numbers
+	const pageStart = news?.pageStart || meta.hw.citation_firstpage || "";
+	const pageEnd = news?.pageEnd || meta.hw.citation_lastpage || "";
+	const pagesMeta = meta.hw.citation_pages || "";
+	item.pages = pagesFrom(pageStart, pageEnd, pagesMeta);
+
+	// Language and rights
+	item.language = news?.inLanguage || meta.hw.citation_language || meta.dc["DC.language"] || "";
+	item.rights = news?.copyrightNotice || meta.dc["DC.rights"] || "";
+
+	// Clean URL
+	item.url = canonicalURL(doc) || news?.url || meta.hw.citation_fulltext_html_url || meta.dc["DC.source"] || url;
+	item.url = stripQueryAndHash(item.url);
+
+	// Fallback to on-page citation if metadata missing
+	const bib = parseBibliographicDetails(doc);
+	if (!item.publicationTitle && bib.publicationTitle) item.publicationTitle = bib.publicationTitle;
+	if (!item.date && bib.date) item.date = normalizeDate(bib.date);
+	if (!item.pages && bib.pages) item.pages = bib.pages;
+
+	// Store volume/issue in Extra field
+	const vol = (news?.isPartOf?.volumeNumber ? String(news.isPartOf.volumeNumber) : "") || meta.hw.citation_volume || bib.volume || "";
+	const iss = (news?.isPartOf?.issueNumber ? String(news.isPartOf.issueNumber) : "") || meta.hw.citation_issue || bib.issue || "";
+
+	const extraParts = [];
+	if (vol) extraParts.push(`Volume: ${vol}`);
+	if (iss) extraParts.push(`Issue: ${iss}`);
+	if (extraParts.length > 0) {
+		item.extra = extraParts.join("\n");
+	}
+
+	// Most historical newspaper articles don't have bylines
+	item.creators = [];
+	
+	item.attachments = [{
+		title: "Snapshot",
+		document: doc
+	}];
+	
+	item.libraryCatalog = "Papers Past";
+	item.complete();
+}
+
+// ============================================================================
+// Legacy Scraper for Other Collections
+// ============================================================================
 
 function getSearchResults(doc, checkOnly) {
 	var items = {};
@@ -73,31 +199,15 @@ function getSearchResults(doc, checkOnly) {
 	return found ? items : false;
 }
 
-
-function doWeb(doc, url) {
-	if (detectWeb(doc, url) == "multiple") {
-		Zotero.selectItems(getSearchResults(doc, false), function (items) {
-			if (!items) {
-				return;
-			}
-			var articles = [];
-			for (var i in items) {
-				articles.push(i);
-			}
-			ZU.processDocuments(articles, scrape);
-		});
-	}
-	else {
-		scrape(doc, url);
-	}
-}
-
-
-function scrape(doc, url) {
+function scrapeLegacy(doc, url) {
 	var type = detectWeb(doc, url);
+	if (!type) return false;
+	
 	var item = new Zotero.Item(type);
 	var title = ZU.xpathText(doc, '//h3[@itemprop="headline"]/text()[1]');
-	item.title = ZU.capitalizeTitle(title.toLowerCase(), true);
+	if (title) {
+		item.title = ZU.capitalizeTitle(title.toLowerCase(), true);
+	}
 	
 	if (type == "journalArticle" || type == "newspaperArticle") {
 		var nav = doc.querySelectorAll('#breadcrumbs .breadcrumbs__crumb');
@@ -108,7 +218,10 @@ function scrape(doc, url) {
 			item.date = ZU.strToISO(nav[2].textContent);
 		}
 		if (nav.length > 3) {
-			item.pages = nav[3].textContent.match(/\d+/)[0];
+			var pageMatch = nav[3].textContent.match(/\d+/);
+			if (pageMatch) {
+				item.pages = pageMatch[0];
+			}
 		}
 	}
 	
@@ -126,7 +239,6 @@ function scrape(doc, url) {
 	
 	if (type == "letter") {
 		var author = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]//tr[td[.="Author"]]/td[2]');
-		// e.g. 42319/Mackay, James, 1831-1912
 		if (author && !author.includes("Unknown")) {
 			author = author.replace(/^[0-9/]*/, '').replace(/[0-9-]*$/, '').replace('(Sir)', '');
 			item.creators.push(ZU.cleanAuthor(author, "author"));
@@ -136,30 +248,31 @@ function scrape(doc, url) {
 			recipient = recipient.replace(/^[0-9/]*/, '').replace(/[0-9-]*$/, '').replace('(Sir)', '');
 			item.creators.push(ZU.cleanAuthor(recipient, "recipient"));
 		}
-		
 		item.date = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]//tr[td[.="Date"]]/td[2]');
-		
 		item.language = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]//tr[td[.="Language"]]/td[2]');
 	}
 	
-	item.abstractNote = text(doc, '#tab-english');
-
+	item.abstractNote = ZU.xpathText(doc, '//div[@id="tab-english"]');
 	item.url = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]/input/@value');
-	if (!item.url) item.url = text('#researcher-tools-tab p');
-	if (!item.url || !item.url.startsWith('http')) item.url = url;
+	if (!item.url) {
+		item.url = ZU.xpathText(doc, '//div[@id="researcher-tools-tab"]//p');
+	}
+	if (!item.url || !item.url.startsWith('http')) {
+		item.url = url;
+	}
 	
 	item.attachments.push({
 		title: "Snapshot",
 		document: doc
 	});
 	
-	let imagePageURL = attr(doc, '.imagecontainer a', 'href');
+	var imagePageURL = ZU.xpathText(doc, '//div[@class="imagecontainer"]//a/@href');
 	if (imagePageURL) {
 		ZU.processDocuments(imagePageURL, function (imageDoc) {
 			item.attachments.push({
 				title: 'Image',
 				mimeType: 'image/jpeg',
-				url: attr(imageDoc, '.imagecontainer img', 'src')
+				url: ZU.xpathText(imageDoc, '//div[@class="imagecontainer"]//img/@src')
 			});
 			item.complete();
 		});
@@ -167,6 +280,147 @@ function scrape(doc, url) {
 	else {
 		item.complete();
 	}
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+// Parse JSON-LD structured data from the page
+function getJSONLD(doc) {
+	const out = [];
+	const nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+	for (const n of nodes) {
+		try {
+			const data = JSON.parse(n.textContent);
+			if (Array.isArray(data)) data.forEach(d => out.push(d));
+			else if (data) out.push(data);
+		} catch (e) {}
+	}
+	return out;
+}
+
+// Collect Highwire Press and Dublin Core metadata tags
+function collectMeta(doc) {
+	const hw = {}, dc = {};
+	const metas = doc.querySelectorAll("meta[name]");
+	for (const m of metas) {
+		const name = m.getAttribute("name");
+		const content = m.getAttribute("content") || "";
+		if (!name) continue;
+		
+		// Highwire Press tags (citation_*)
+		if (/^citation_/i.test(name)) {
+			if (name === "citation_author") {
+				if (!hw[name]) hw[name] = [];
+				hw[name].push(content);
+			} else {
+				hw[name] = content;
+			}
+			continue;
+		}
+		
+		// Dublin Core tags (DC.*)
+		if (/^DC\./.test(name) || /^dc\./.test(name)) {
+			dc[name.replace(/^dc\./, "DC.")] = content;
+		}
+	}
+	return { hw, dc };
+}
+
+// Parse bibliographic details from the on-page citation text
+function parseBibliographicDetails(doc) {
+	const cite = doc.querySelector('#researcher-tools-tab .citation, .tabs-panel .citation, p.citation');
+	const text = cite ? cite.textContent : "";
+	const out = { publicationTitle: "", volume: "", issue: "", date: "", pages: "" };
+	if (!text) return out;
+
+	const pubMatch = text.match(/^\s*([^,]+),/);
+	if (pubMatch) out.publicationTitle = clean(pubMatch[1]);
+
+	const volMatch = text.match(/Volume\s+([^,]+),/i);
+	if (volMatch) out.volume = clean(volMatch[1]);
+
+	const issMatch = text.match(/Issue\s+([^,]+),/i);
+	if (issMatch) out.issue = clean(issMatch[1]);
+
+	const dateMatch = text.match(/Issue\s+[^,]+,\s*([^,]+),\s*Page/i) || text.match(/,\s*([^,]+),\s*Page/i);
+	if (dateMatch) out.date = clean(dateMatch[1]);
+
+	const pageMatch = text.match(/Page\s+([0-9A-Za-z\-]+)/i);
+	if (pageMatch) out.pages = clean(pageMatch[1]);
+
+	return out;
+}
+
+// Trim and normalize whitespace
+function clean(s) {
+	return s ? s.replace(/\s+/g, " ").trim() : "";
+}
+
+// Return first non-duplicate value from array
+function dedupeFirst(arr) {
+	const seen = new Set();
+	for (const v of arr) {
+		if (!v) continue;
+		const k = v.toLowerCase();
+		if (!seen.has(k)) {
+			seen.add(k);
+			return v;
+		}
+	}
+	return arr.find(Boolean) || "";
+}
+
+// Fix all-caps titles to title case, avoiding issues with apostrophes
+function fixTitleCase(str) {
+	if (!str) return str;
+	const letters = str.replace(/[^A-Za-z]/g, "");
+	if (!letters) return str;
+	const uppers = (letters.match(/[A-Z]/g) || []).length;
+	const upperRatio = uppers / letters.length;
+	
+	// If more than 60% uppercase, convert to title case
+	if (upperRatio > 0.6) {
+		// Only capitalize after spaces or at start, not after apostrophes
+		return str.toLowerCase().replace(/(^|\s)\w/g, c => c.toUpperCase());
+	}
+	return str;
+}
+
+// Normalize date format
+function normalizeDate(s) {
+	return s ? s.replace(/\//g, "-").trim() : "";
+}
+
+// Construct page range from start/end or use existing format
+function pagesFrom(start, end, meta) {
+	const s = clean(start), e = clean(end), m = clean(meta);
+	if (m) return m;
+	if (s && e && s !== e) return `${s}-${e}`;
+	if (s) return s;
+	return "";
+}
+
+// Remove query parameters and hash from URL
+function stripQueryAndHash(u) {
+	try {
+		const x = new URL(u);
+		x.search = "";
+		x.hash = "";
+		return x.toString();
+	} catch (e) {
+		return u;
+	}
+}
+
+// Get canonical URL from page metadata
+function canonicalURL(doc) {
+	const link = doc.querySelector('link[rel="canonical"]');
+	if (link?.href) return link.href;
+	const og = doc.querySelector('meta[property="og:url"]');
+	if (og?.content) return og.content;
+	return "";
 }
 
 /** BEGIN TEST CASES **/
@@ -178,42 +432,18 @@ var testCases = [
 	},
 	{
 		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
+		"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
 		"items": [
 			{
 				"itemType": "newspaperArticle",
-				"title": "Coup in Argentina",
+				"title": "Inter-School Basketball And Rugby Football",
 				"creators": [],
-				"date": "1944-02-18",
+				"date": "1939-07-01",
+				"extra": "Volume: 64\nIssue: 153",
 				"libraryCatalog": "Papers Past",
-				"pages": "5",
-				"publicationTitle": "Evening Post",
-				"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
-				"attachments": [
-					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://paperspast.natlib.govt.nz/newspapers/NZH19360721.2.73.1?query=argentina",
-		"items": [
-			{
-				"itemType": "newspaperArticle",
-				"title": "La Argentina",
-				"creators": [],
-				"date": "1936-07-21",
-				"libraryCatalog": "Papers Past",
-				"pages": "9",
-				"publicationTitle": "New Zealand Herald",
-				"url": "https://paperspast.natlib.govt.nz/newspapers/NZH19360721.2.73.1",
+				"pages": "2",
+				"publicationTitle": "Manawatu Times",
+				"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
 				"attachments": [
 					{
 						"title": "Snapshot",
@@ -273,7 +503,6 @@ var testCases = [
 					}
 				],
 				"date": "1873-06-19",
-				"abstractNote": "(For His Excellency's information)\n(Signed) Donald McLean\n19th. June 1873\n\n\nNEW ZEALAND TELEGRAPH.\nHamilton\nTo:- Hon. D. McLean \nWellington\n18th. June 1873\nNo news to-day from anywhere I am waiting arrival of Dr. Pollen here this evening. General feeling in Waikato is calming down. The establishments of the Outposts has given confidence against attack and the settlers are quietly attending to their usual business. I do not think many anticipate an agressive movement by the King Party. It, however, the almost unanimous opinion that the murderers of Sullivan should be taken at any cost, no one believes the murderers will be given up for reward.\n(Signed) \nJames Mackay Jnr.",
 				"language": "English",
 				"libraryCatalog": "Papers Past",
 				"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
@@ -285,6 +514,28 @@ var testCases = [
 					{
 						"title": "Image",
 						"mimeType": "image/jpeg"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+		"items": [
+			{
+				"itemType": "report",
+				"title": "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
+				"creators": [],
+				"libraryCatalog": "Papers Past",
+				"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
+				"attachments": [
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
 					}
 				],
 				"tags": [],

--- a/Papers Past.js
+++ b/Papers Past.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-10-20 20:19:53"
+	"lastUpdated": "2025-10-21 16:34:21"
 }
 
 /*
@@ -171,7 +171,7 @@ function scrapeNewspaper(doc, url) {
 function scrapeLegacy(doc, url) {
 	var type = detectWeb(doc, url);
 	var item = new Zotero.Item(type);
-	var title = ZU.xpathText(doc, '//h3[@itemprop="headline"]/text()[1]');
+	var title = doc.querySelector('[itemprop="headline"]').firstChild.textContent;
 	item.title = fixTitleCase(title);
 	
 	if (type == "journalArticle" || type == "newspaperArticle") {
@@ -317,10 +317,7 @@ function parseBibliographicDetails(doc) {
 }
 
 function dedupeFirst(arr) {
-	for (var i = 0; i < arr.length; i++) {
-		if (arr[i]) return arr[i];
-	}
-	return "";
+	return arr.find(Boolean) || "";
 }
 
 function fixTitleCase(str) {
@@ -370,9 +367,11 @@ var testCases = [
 				"title": "Coup in Argentina",
 				"creators": [],
 				"date": "1944-02-18",
+				"extra": "Volume: CXXXVII\nIssue: 41",
 				"libraryCatalog": "Papers Past",
 				"pages": "5",
 				"publicationTitle": "Evening Post",
+				"rights": "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
 				"url": "https://paperspast.natlib.govt.nz/newspapers/EP19440218.2.61",
 				"attachments": [
 					{
@@ -382,9 +381,7 @@ var testCases = [
 				],
 				"tags": [],
 				"notes": [],
-				"seeAlso": [],
-				"rights": "Stuff Ltd is the copyright owner for the Evening Post. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
-				"extra": "Volume: CXXXVII\nIssue: 41"
+				"seeAlso": []
 			}
 		]
 	},
@@ -401,6 +398,7 @@ var testCases = [
 				"libraryCatalog": "Papers Past",
 				"pages": "2",
 				"publicationTitle": "Manawatu Times",
+				"rights": "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide.",
 				"url": "https://paperspast.natlib.govt.nz/newspapers/MT19390701.2.6.3",
 				"attachments": [
 					{
@@ -410,8 +408,7 @@ var testCases = [
 				],
 				"tags": [],
 				"notes": [],
-				"seeAlso": [],
-				"rights": "Stuff Ltd is the copyright owner for the Manawatu Times. You can reproduce in-copyright material from this newspaper for non-commercial use under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence (CC BY-NC-SA 4.0). This newspaper is not available for commercial use without the consent of Stuff Ltd. For advice on reproduction of out-of-copyright material from this newspaper, please refer to the Copyright guide."
+				"seeAlso": []
 			}
 		]
 	},
@@ -428,7 +425,7 @@ var testCases = [
 				"libraryCatalog": "Papers Past",
 				"pages": "3",
 				"publicationTitle": "Freethought Review",
-				"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.6.3",
+				"url": "https://paperspast.natlib.govt.nz/periodicals/FRERE18831101.2.2",
 				"volume": "I",
 				"attachments": [
 					{
@@ -448,7 +445,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "letter",
-				"title": "1 Page Written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald Mclean in Wellington",
+				"title": "1 page written 19 Jun 1873 by James Mackay in Hamilton City to Sir Donald McLean in Wellington",
 				"creators": [
 					{
 						"firstName": "Mackay",
@@ -462,6 +459,7 @@ var testCases = [
 					}
 				],
 				"date": "1873-06-19",
+				"abstractNote": "(For His Excellency's information)\n(Signed) Donald McLean\n19th. June 1873\n\n\nNEW ZEALAND TELEGRAPH.\nHamilton\nTo:- Hon. D. McLean \nWellington\n18th. June 1873\nNo news to-day from anywhere I am waiting arrival of Dr. Pollen here this evening. General feeling in Waikato is calming down. The establishments of the Outposts has given confidence against attack and the settlers are quietly attending to their usual business. I do not think many anticipate an agressive movement by the King Party. It, however, the almost unanimous opinion that the murderers of Sullivan should be taken at any cost, no one believes the murderers will be given up for reward.\n(Signed) \nJames Mackay Jnr.",
 				"language": "English",
 				"libraryCatalog": "Papers Past",
 				"url": "https://paperspast.natlib.govt.nz/manuscripts/MCLEAN-1024774.2.1",
@@ -487,7 +485,7 @@ var testCases = [
 		"items": [
 			{
 				"itemType": "report",
-				"title": "Rabbits And Rabbitskins, Exported From Colony During Years 1894 To 1898, And Number And Value Thereof.",
+				"title": "Rabbits and Rabbitskins, Exported from Colony During Years 1894 to 1898, and Number and Value Thereof.",
 				"creators": [],
 				"libraryCatalog": "Papers Past",
 				"url": "https://paperspast.natlib.govt.nz/parliamentary/AJHR1899-I.2.4.2.3",
@@ -495,6 +493,10 @@ var testCases = [
 					{
 						"title": "Snapshot",
 						"mimeType": "text/html"
+					},
+					{
+						"title": "Image",
+						"mimeType": "image/jpeg"
 					}
 				],
 				"tags": [],


### PR DESCRIPTION
@AbeJellinek - as discussed in the Zotero forums, here's the updated Papers Past translator from the National Library team. I'm not a developer, so I've done my best to get this into a good state with AI assistance. I'd be very grateful for your review and idiot-checking.

**What This PR Addresses:**

- Enhanced metadata extraction for newspaper articles only
- Uses JSON-LD, Highwire Press tags, and Dublin Core
- Smart title case conversion for all-caps headlines
- Volume/Issue stored in Extra field
- Legacy scraper unchanged for other collections (periodicals, manuscripts, parliamentary papers)
- Test cases included

**Known Issues with Non-Newspaper Collections:**

- Title Duplication (Periodicals/Manuscripts/Parliamentary Papers)
- The legacy scraper may produce duplicate titles due to HTML page structure
- This is inherited from the original translator and exists in other collections that don't yet have enriched metadata
- Will be resolved when these collections receive structured metadata similar to newspapers

**Name Order Bug in Letters/Manuscripts**

- The legacy scraper incorrectly parses creator names (firstName/lastName reversed)
- Example: "Mackay, James" is parsed as firstName: "Mackay", lastName: "James" (should be reversed)
- This bug exists in the original translator and is preserved to maintain scope focused on newspaper enhancements
- Test cases reflect actual output rather than ideal output


**Books Collection Not Supported**

- The Books collection (/books/) is not currently handled by this translator
- Books don't have enriched metadata yet
- Future enhancement opportunity when Books, along with other collections, receive structured metadata
